### PR TITLE
update passthrough for SVG to match asset location

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -215,7 +215,7 @@ module.exports = function(eleventyConfig) {
   });
 
   // Copy folders or static assets e.g. images to site output
-  eleventyConfig.addPassthroughCopy({"assets/icons/favicon.svg" : "/favicon.svg"});
+  eleventyConfig.addPassthroughCopy({"assets/uploads/favicon.svg" : "/favicon.svg"});
 
   // Disable 11ty dev server live reload when using CMS locally
   eleventyConfig.setServerOptions({


### PR DESCRIPTION
It looks like this might have been missed from #7 as the svg icon is missing in Firefox on main, this sorts the passthrough so the svg favicon exists under /_site